### PR TITLE
Do not install tests folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email='itrotts@willowgarage.com, william@osrfoundation.org',
     url='http://github.com/wjwwood/parse_cmake',
     description='Parser for CMakeLists.txt files',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     install_requires=['pyPEG2'],
     tests_require=['nose', 'flake8'],
     test_suite='nose.collector',


### PR DESCRIPTION
When installing this package, the `tests` folder also gets installed. This can be avoided with the `exclude` argument for `find_packages`.